### PR TITLE
Update the half-lives used in the 31Mg decay series calculations

### DIFF
--- a/bfit/fitting/decay_31mg.py
+++ b/bfit/fitting/decay_31mg.py
@@ -15,9 +15,10 @@ import numpy as np
 # GLOBAL CONSTANTS ===========================================================
 
 # half-lives (s)
-T_12_31Mg = 0.235
+# see: https://www-nds.iaea.org/relnsd/vcharthtml/VChartHTML.html
+T_12_31Mg = 0.236
 T_12_31Al = 0.644
-T_12_31Si = 2.632*3600  # seconds
+T_12_31Si = 157.36 * 60 # seconds
 T_12_31P = np.inf
 T_12_30Al = 3.62
 T_12_30Si = np.inf


### PR DESCRIPTION
Small updates to the values (see e.g., the IAEA NDS [LiveChart](https://www-nds.iaea.org/relnsd/vcharthtml/VChartHTML.html)).

This keeps consistency with the recent updates in: https://github.com/dfujim/bdata/pull/4/commits/03be1b197c0a50cc17abab297fd16b74821f840b.