### PR TITLE
replace the deprecated use of collections.Iterable

### DIFF
--- a/bfit/fitting/fit_bdata.py
+++ b/bfit/fitting/fit_bdata.py
@@ -2,7 +2,7 @@
 # Derek Fujimoto
 # Nov 2018
 
-import collections
+from collections.abc import Iterable
 import numpy as np
 from bdata import bdata
 from scipy.optimize import curve_fit
@@ -77,7 +77,7 @@ def fit_bdata(data, fn, omit=None, rebin=None, shared=None, hist_select='',
         ndata = 1
     
     # get fn
-    if not isinstance(fn, collections.Iterable):
+    if not isinstance(fn, Iterable):
         fn = [fn]
     else:
         fn = list(fn)

--- a/bfit/fitting/fitter.py
+++ b/bfit/fitting/fitter.py
@@ -6,7 +6,7 @@ import bfit.fitting.functions as fns
 from bfit.fitting.decay_31mg import fa_31Mg
 from bfit.fitting.gen_init_par import gen_init_par
 from functools import partial
-import collections
+from collections.abc import Iterable
 import numpy as np
 import bdata as bd
 import pandas as pd
@@ -240,7 +240,7 @@ class fitter(object):
                                         **kwargs)
         
         # set up output dataframe
-        if not isinstance(chis, collections.Iterable):   # single run
+        if not isinstance(chis, Iterable):   # single run
             pars = [pars]
             stds_l = [stds_l]
             stds_h = [stds_h]

--- a/bfit/fitting/global_bdata_fitter.py
+++ b/bfit/fitting/global_bdata_fitter.py
@@ -5,7 +5,7 @@
 from bfit.fitting.global_fitter import global_fitter
 import bdata as bd
 import numpy as np
-import collections
+from collections.abc import Iterable
 
 # =========================================================================== #
 class global_bdata_fitter(global_fitter):
@@ -41,7 +41,7 @@ class global_bdata_fitter(global_fitter):
         ndata = len(data)
         
         # Set rebin
-        if not isinstance(rebin, collections.Iterable):
+        if not isinstance(rebin, Iterable):
             rebin = [rebin]*ndata
         
         # Get asymmetry


### PR DESCRIPTION
- use `collections.abc.Iterable` instead of `collections.Iterable`, which doesn't exist in newer Python versions (e.g., 3.10).