### PR TITLE
update package publishing workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,11 +21,11 @@ jobs:
     - name: Install dependencies
       run: |
         python3 -m pip install --upgrade pip
-        pip install setuptools twine Cython numpy
+        pip install build wheel twine meson Cython numpy
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        python setup.py sdist
+        python -m build --sdist
         twine upload dist/*


### PR DESCRIPTION
Replace the setuptools-based workflow with one that is compatible with the current build system (meson).