### PR TITLE
explicitly start new process as a "fork"

### DIFF
--- a/bfit/gui/popup_ongoing_process.py
+++ b/bfit/gui/popup_ongoing_process.py
@@ -4,7 +4,7 @@
 
 from tkinter import *
 from tkinter import ttk
-from multiprocessing import Process
+import multiprocessing
 from queue import Empty
 
 import bfit.backend.colors as colors
@@ -106,7 +106,7 @@ class popup_ongoing_process(object):
     def run(self):
         
         # start fit
-        self.process = Process(target = self.target)
+        self.process = multiprocessing.get_context("fork").Process(target = self.target)
         self.process.start()
         
         # disable GUI


### PR DESCRIPTION
In Python 3.14, the default way that `multiprocessing` starts a new process on POSIX platforms was switched from "fork" to "forkserver". This patch ensures that each process is explicitly started as a "fork" (without this, the popup window hangs during fitting).