### PR TITLE
macOS GUI compatibility

### DIFF
--- a/bfit/gui/bfit.py
+++ b/bfit/gui/bfit.py
@@ -439,7 +439,15 @@ class bfit(object):
                             borderwidth=1,
                             background=colors.background)
 
+        # Make bfit work on MacOS
         ttk_style.configure('TButton', foreground='black', background='white')
+
+        ttk_style.map("TCombobox",
+            fieldbackground=[("readonly", "white")],
+            foreground=[("readonly", "black")],
+            selectforeground=[("readonly", "black")],
+            selectbackground=[("readonly", "white")],
+        )
 
         # icon
         self.set_icon(root)

--- a/bfit/gui/bfit.py
+++ b/bfit/gui/bfit.py
@@ -420,8 +420,9 @@ class bfit(object):
                            fieldbackground=[('selected', colors.selected)])
 
         ttk_style.configure('TNotebook.Tab', padding=[50, 2])
-        ttk_style.configure("TNotebook.Tab", background=colors.background)
-        ttk_style.map("TNotebook.Tab", background=[("selected", colors.tab)])
+        ttk_style.map("TNotebook.Tab",
+                      background=[("selected", colors.tab)],
+                      foreground=[("selected", 'black')])
 
         ttk_style.map("TCheckbutton", foreground=[('selected', colors.selected),
                                                  ('disabled', colors.disabled)],
@@ -437,6 +438,8 @@ class bfit(object):
         ttk_style.configure('TProgressbar',
                             borderwidth=1,
                             background=colors.background)
+
+        ttk_style.configure('TButton', foreground='black', background='white')
 
         # icon
         self.set_icon(root)

--- a/bfit/gui/popup_add_param.py
+++ b/bfit/gui/popup_add_param.py
@@ -103,7 +103,7 @@ class popup_add_param(template_fit_popup):
                 '\nfrom the reserved modules in the parameter definition.'+\
                 '\nEx: "mypar = 1/(1_T1*TEMP)"'+\
                 '\n\nAccepts LaTeX input for the new parameter.'+\
-                '\nEx: "$\eta_\mathrm{f}$ (Tesla) = B0 * np.exp(-amp**2)"' +\
+                r'\nEx: "$\eta_\mathrm{f}$ (Tesla) = B0 * np.exp(-amp**2)"' +\
                 '\n\nValues taken as shown in fit results, with no unit scaling.'
 
         # gridding

--- a/bfit/gui/tab_fit_files.py
+++ b/bfit/gui/tab_fit_files.py
@@ -272,7 +272,7 @@ class fit_files(object):
         update_button = ttk.Button(button_frame, text='Update', command=self.update_param)
         export_button = ttk.Button(button_frame, text='Export', command=self.export)
         show_button = ttk.Button(button_frame, text='Compare', command=self.show_all_results)
-        model_fit_button = ttk.Button(button_frame, text='Fit a\nModel',
+        model_fit_button = ttk.Button(button_frame, text='Fit Model',
                                       command=self.do_fit_model)
 
         # menus for x and y values

--- a/bfit/gui/template_fit_popup.py
+++ b/bfit/gui/template_fit_popup.py
@@ -145,7 +145,7 @@ class template_fit_popup(object):
         # check for new parameters
         new_par = []
         for eq in eqn:
-            lst = re.split('\W+', eq)    # split list non characters
+            lst = re.split(r'\W+', eq)    # split list non characters
 
             # throw out known things: numbers numpy equations
             delist = []


### PR DESCRIPTION
A small PR to improve the GUI usability on macOS. 

Bugs fixed: 
The button labels and tab switcher were unreadable, the comboboxes deselected when you selected another one, and there were invalid escape character warnings when compiled with python 3.12.  

Before: 
<img width="1563" height="888" alt="Screenshot 2026-07-21 at 10 58 54 AM" src="https://github.com/user-attachments/assets/9a083eee-f3ba-43e9-a428-f85d0fcb7383" />

After:
<img width="1564" height="888" alt="Screenshot 2026-07-21 at 10 55 36 AM" src="https://github.com/user-attachments/assets/511cf17f-639c-4738-b419-ce07ad04c1fc" />

GUI manually tested on macOS and linux. No automated tests have been run. 